### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/medapp/src/main/java/com/coding/medapp/services/UserServices.java
+++ b/medapp/src/main/java/com/coding/medapp/services/UserServices.java
@@ -109,10 +109,21 @@ public class UserServices {
     }
 
     public String saveProfileImage(MultipartFile profileImage) throws IOException {
-        String fileName = UUID.randomUUID().toString() + profileImage.getOriginalFilename();
-        Path filePath = Paths.get(uploadDirectory, fileName);
+        String originalFileName = profileImage.getOriginalFilename();
+        if (originalFileName == null || originalFileName.contains("..") || originalFileName.contains("/") || originalFileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid filename");
+        }
+        
+        String sanitizedFileName = UUID.randomUUID().toString() + "_" + originalFileName.replaceAll("[^a-zA-Z0-9._-]", "");
+        Path filePath = Paths.get(uploadDirectory, sanitizedFileName).normalize();
+        Path uploadDirPath = Paths.get(uploadDirectory).normalize();
+        
+        if (!filePath.startsWith(uploadDirPath)) {
+            throw new IllegalArgumentException("File path traversal detected");
+        }
+        
         Files.copy(profileImage.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
-        return "/images/" + fileName;
+        return "/images/" + sanitizedFileName;
     }
 
     public void updateUser(User user) {


### PR DESCRIPTION
Potential fix for [https://github.com/IgnacioF99/MedApp/security/code-scanning/6](https://github.com/IgnacioF99/MedApp/security/code-scanning/6)

To fix this issue, we need to validate the user-provided filename before constructing the file path. Specifically:
1. Disallow filenames containing path traversal sequences (e.g., `".."`), path separators (`"/"` or `"\\"`), or other special characters that could lead to unintended behavior.
2. Normalize the constructed file path and ensure that it resides within the intended `uploadDirectory`.

We will:
- Add validation logic to check and sanitize `profileImage.getOriginalFilename()`.
- Use `Path` methods to ensure that the resolved `filePath` remains within `uploadDirectory`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
